### PR TITLE
Add OSGI-Wrapper for RxJava2 (+reactive-stream dependency + interop library)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,10 @@
     <module>hibernate-validator</module>
     <module>jersey</module>
     <module>mustache-compiler</module>
+    <module>reactive-streams</module>
     <module>rxjava</module>
+    <module>rxjava2</module>
+    <module>rxjava2-interop</module>
   </modules>
 
   <build>

--- a/reactive-streams/pom.xml
+++ b/reactive-streams/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  wcm.io
+  %%
+  Copyright (C) 2018 wcm.io
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.wcm.osgi.wrapper</groupId>
+    <artifactId>io.wcm.osgi.wrapper.parent</artifactId>
+    <version>1.0.6</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <pkgVersion>1.0.2</pkgVersion>
+    <osgiVersion>${pkgVersion}</osgiVersion>
+  </properties>
+
+  <groupId>io.wcm.osgi.wrapper</groupId>
+  <artifactId>io.wcm.osgi.wrapper.reactive-streams</artifactId>
+  <version>1.0.2-0000-SNAPSHOT</version>
+  <packaging>bundle</packaging>
+  <name>reactive-streams</name>
+
+  <description>
+    Reactive Streams is an initiative to provide a standard API for asynchronous stream processing with non-blocking back pressure
+  </description>
+  <organization>
+    <url>http://www.reactive-streams.org/</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>CC0 1.0 Universal (CC0 1.0) Public Domain Dedication</name>
+      <url>http://creativecommons.org/publicdomain/zero/1.0/</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/wcm-io/wcm-io-osgi-wrapper.git</connection>
+    <developerConnection>scm:git:https://github.com/wcm-io/wcm-io-osgi-wrapper.git</developerConnection>
+    <url>https://github.com/wcm-io/wcm-io-osgi-wrapper</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.reactivestreams</groupId>
+      <artifactId>reactive-streams</artifactId>
+      <version>${pkgVersion}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <!-- Do not inline jars, include as jar files -->
+            <Embed-Dependency>*;scope=compile|runtime;inline=false</Embed-Dependency>
+            <Embed-Transitive>false</Embed-Transitive>
+            <!-- use _exportcontents instead of Export-Package to avoid conflict with Embed-Dependency an inline=true -->
+            <_exportcontents>
+              org.reactivestreams.*;version=${osgiVersion}
+            </_exportcontents>
+            <Import-Package>
+              *
+            </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/rxjava/pom.xml
+++ b/rxjava/pom.xml
@@ -3,7 +3,7 @@
   #%L
   wcm.io
   %%
-  Copyright (C) 2014 wcm.io
+  Copyright (C) 2018 wcm.io
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,13 +30,13 @@
   </parent>
 
   <properties>
-    <pkgVersion>1.0.14</pkgVersion>
+    <pkgVersion>1.3.8</pkgVersion>
     <osgiVersion>${pkgVersion}</osgiVersion>
   </properties>
 
   <groupId>io.wcm.osgi.wrapper</groupId>
   <artifactId>io.wcm.osgi.wrapper.rxjava</artifactId>
-  <version>1.0.14-0001-SNAPSHOT</version>
+  <version>1.3.8-0000-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>rxjava</name>
 

--- a/rxjava2-interop/pom.xml
+++ b/rxjava2-interop/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  wcm.io
+  %%
+  Copyright (C) 2018 wcm.io
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.wcm.osgi.wrapper</groupId>
+    <artifactId>io.wcm.osgi.wrapper.parent</artifactId>
+    <version>1.0.6</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <pkgVersion>0.13.3</pkgVersion>
+    <osgiVersion>${pkgVersion}</osgiVersion>
+  </properties>
+
+  <groupId>io.wcm.osgi.wrapper</groupId>
+  <artifactId>io.wcm.osgi.wrapper.rxjava2-interop</artifactId>
+  <version>0.13.3-0000-SNAPSHOT</version>
+  <packaging>bundle</packaging>
+  <name>rxjava2-interop</name>
+
+  <description>
+    Library to convert between RxJava 1.x and 2.x reactive types.
+  </description>
+  <organization>
+    <url>https://github.com/akarnokd/rxjava2-interop</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/wcm-io/wcm-io-osgi-wrapper.git</connection>
+    <developerConnection>scm:git:https://github.com/wcm-io/wcm-io-osgi-wrapper.git</developerConnection>
+    <url>https://github.com/wcm-io/wcm-io-osgi-wrapper</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <dependencies>
+    <dependency>
+       <groupId>com.github.akarnokd</groupId>
+       <artifactId>rxjava2-interop</artifactId>
+       <version>${pkgVersion}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <!-- Do not inline jars, include as jar files -->
+            <Embed-Dependency>*;scope=compile|runtime;inline=false</Embed-Dependency>
+            <Embed-Transitive>false</Embed-Transitive>
+            <!-- use _exportcontents instead of Export-Package to avoid conflict with Embed-Dependency an inline=true -->
+            <_exportcontents>
+              hu.akarnokd.rxjava.interop.*;version=${osgiVersion}
+            </_exportcontents>
+            <Import-Package>
+              *
+            </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/rxjava2/pom.xml
+++ b/rxjava2/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  wcm.io
+  %%
+  Copyright (C) 2018 wcm.io
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.wcm.osgi.wrapper</groupId>
+    <artifactId>io.wcm.osgi.wrapper.parent</artifactId>
+    <version>1.0.6</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <pkgVersion>2.2.4</pkgVersion>
+    <osgiVersion>${pkgVersion}</osgiVersion>
+  </properties>
+
+  <groupId>io.wcm.osgi.wrapper</groupId>
+  <artifactId>io.wcm.osgi.wrapper.rxjava2</artifactId>
+  <version>2.2.4-0000-SNAPSHOT</version>
+  <packaging>bundle</packaging>
+  <name>rxjava2</name>
+
+  <description>
+    RxJava Version 2. Java VM implementation of Reactive Extensions - a library for composing asynchronous and event-based programs by using observable sequences
+  </description>
+  <organization>
+    <url>https://github.com/ReactiveX/RxJava</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/wcm-io/wcm-io-osgi-wrapper.git</connection>
+    <developerConnection>scm:git:https://github.com/wcm-io/wcm-io-osgi-wrapper.git</developerConnection>
+    <url>https://github.com/wcm-io/wcm-io-osgi-wrapper</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.reactivex.rxjava2</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>${pkgVersion}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <!-- Do not inline jars, include as jar files -->
+            <Embed-Dependency>*;scope=compile|runtime;inline=false</Embed-Dependency>
+            <Embed-Transitive>false</Embed-Transitive>
+            <!-- use _exportcontents instead of Export-Package to avoid conflict with Embed-Dependency an inline=true -->
+            <_exportcontents>
+              io.reactivex.*;version=${osgiVersion}
+            </_exportcontents>
+            <Import-Package>
+              *
+            </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
Note: the update for rxjava 1.x to version 1.3.8 is required because the interop library depends on it.